### PR TITLE
optimise: explicit model selection for subagents

### DIFF
--- a/plugin/commands/implement.md
+++ b/plugin/commands/implement.md
@@ -145,7 +145,9 @@ Execute tasks in dependency order:
 3. Mark as completed: `TaskUpdate` with `status: "completed"`
 4. Check if any dependent tasks are now unblocked
 
-**For parallel groups**: When all tasks in a parallel group are ready (dependencies met), execute them. Use the Task tool to dispatch independent subagents for file-writing tasks on different files. Practical limit: 2-3 concurrent subagents. Wait for all to complete before moving to dependent tasks.
+**For parallel groups**: When all tasks in a parallel group are ready (dependencies met), execute them. Use the Task tool to dispatch independent subagents for file-writing tasks on different files, with `model: "sonnet"`:
+   - **Why sonnet**: File-writing subagents receive structured instructions (what file to create, what content, which patterns to follow). Sonnet handles this reliably at ~5x less cost than Opus. The orchestrating agent handles architectural decisions; subagents execute them.
+   - Practical limit: 2-3 concurrent subagents. Wait for all to complete before moving to dependent tasks.
 
 **At validator gates**:
 

--- a/plugin/commands/plan.md
+++ b/plugin/commands/plan.md
@@ -36,13 +36,16 @@ You **MUST** consider the user input before proceeding (if not empty).
    - For each dependency → best practices task
    - For each integration → patterns task
 
-2. **Generate and dispatch research agents**:
+2. **Generate and dispatch research agents** using the Task tool with `subagent_type: "Explore"` and `model: "haiku"`:
+   - **Why haiku**: Research subagents retrieve and summarise existing information — they don't make architectural decisions. Haiku is sufficient for information gathering and costs ~10x less than Opus. The implementing agent synthesises the research into decisions using the main model.
 
    ```text
    For each unknown in Technical Context:
      Task: "Research {unknown} for {feature context}"
+       → subagent_type: "Explore", model: "haiku"
    For each technology choice:
      Task: "Find best practices for {tech} in {domain}"
+       → subagent_type: "Explore", model: "haiku"
    ```
 
 3. **Consolidate findings** in `design/research.md` using format:


### PR DESCRIPTION
## Summary
- plan.md: Research subagents now dispatch with model haiku -- information gathering saves ~10x cost per research task
- implement.md: File-writing subagents now dispatch with model sonnet -- structured instruction execution at ~5x less cost than Opus
- Validator gates remain on Sonnet (already explicit, unchanged)

## Context
Validated by the 008 pipeline token forensic analysis. Research subagent outputs were used without re-investigation (confirming Haiku sufficiency). File-writing subagent outputs were correct from structured instructions (confirming Sonnet sufficiency).

Projected savings: ~3.40 per pipeline (Haiku research ~1.40 + Sonnet file-writing ~2.00).

Design reference: animis-analytics-agent/tmp/harness-evolution-design-document.md Section 5, workstreams W5.2 and W5.3.

## Test plan
- [ ] Run /plan on next feature -- verify research agents dispatch as Haiku
- [ ] Run /implement on next feature -- verify parallel file-writing subagents dispatch as Sonnet
- [ ] Verify validator gates still dispatch as Sonnet (no regression)

Generated with [Claude Code](https://claude.com/claude-code)